### PR TITLE
Enable specification of a member as HA pair

### DIFF
--- a/grid-templates/gm-ha.yaml
+++ b/grid-templates/gm-ha.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2015-10-15
+heat_template_version: 2013-05-23
 description: Launches an HA pair GM, and configures the Neutron ports such that VRRP will work with IPv4 and virtual router ID 200. You must still manually configure HA on the grid.
 parameters:
   name:
@@ -43,16 +43,17 @@ parameters:
     type: string
     description: NIOS image to use
     default: nios-7.3.0-314102-160G-1420
-    #default: nios-7.3.0-314102-55G-820
     constraints:
       - custom_constraint: glance.image
   flavor:
     type: string
     description: NIOS flavor to use (must match image)
     default: vnios-1420.160
-    #default: vnios-820.55
     constraints:
       - custom_constraint: nova.flavor
+  virtual_router_id:
+    type: number
+    default: 200
 resources:
   vip_port:
     type: OS::Neutron::Port
@@ -71,9 +72,9 @@ resources:
 
   ha_port_node_1:
     type: OS::Neutron::Port
+    depends_on: [vip_port]
     properties:
       network: {get_param: lan1_network}
-      allowed_address_pairs: [{ip_address: {get_attr: [vip_port, fixed_ips, 0, ip_address]}, mac_address: "00:00:5e:00:01:c8"}]
       security_groups: [{get_param: security_group}]
 
   lan1_port_node_2:
@@ -84,9 +85,9 @@ resources:
 
   ha_port_node_2:
     type: OS::Neutron::Port
+    depends_on: [vip_port]
     properties:
       network: {get_param: lan1_network}
-      allowed_address_pairs: [{ip_address: {get_attr: [vip_port, fixed_ips, 0, ip_address]}, mac_address: "00:00:5e:00:01:c8"}]
       security_groups: [{get_param: security_group}]
 
   vip_floating_ip:
@@ -160,6 +161,20 @@ resources:
             $temp_license: { get_param: temp_license }
             $v4_addr: { get_attr: [lan1_port_node_2, fixed_ips, 0, ip_address] }
             $v4_gw: { get_attr: [lan1_port_node_2, subnets, 0, gateway_ip] }
+  ha_pair:
+    type: Infoblox::Grid::HaPair
+    depends_on: [node_1, node_2]
+    properties:
+      name: 'HaPair1'
+      vip: { get_resource: vip_port }
+      node1_ha: { get_resource: ha_port_node_1 }
+      node2_ha: { get_resource: ha_port_node_2 }
+      node1_lan1: { get_resource: lan1_port_node_1 }
+      node2_lan1: { get_resource: lan1_port_node_2 }
+      vip_floating_ip: { get_attr: [vip_floating_ip, floating_ip_address] }
+      node1_floating_ip: { get_attr: [node_1_floating_ip, floating_ip_address] }
+      node2_floating_ip: { get_attr: [node_2_floating_ip, floating_ip_address] }
+      virtual_router_id: { get_param: virtual_router_id }
 outputs:
   node1_lan1_ip:
     description: The LAN1 IP address of node 1.

--- a/grid-templates/member-ha.yaml
+++ b/grid-templates/member-ha.yaml
@@ -1,0 +1,154 @@
+heat_template_version: 2014-10-16
+description: An Infoblox Grid Member
+parameters:
+  external_network:
+    type: string
+    description: the external network for floating IP allocations
+    default: public-138-net
+  model:
+    type: string
+    description: vNIOS Model
+    default: IB-VM-810
+  flavor:
+    type: string
+    description: vNIOS Flavor
+    default: vnios-810.55
+  image:
+    type: string
+    description: vNIOS image
+    default: nios-7.3.0-314102-55G-810
+  wapi_url:
+    type: string
+    description: the URL to access the GM WAPI from the Heat engine
+  wapi_username:
+    type: string
+    description: the username for the WAPI access
+  wapi_password:
+    type: string
+    description: the username for the WAPI access
+  wapi_sslverify:
+    type: string
+    description: the value for SSL Verify (true/false/certificate path)
+    default: false
+  gm_vip:
+    type: string
+    description: the VIP of the GM, to be used by members for joining the grid
+  gm_cert:
+    type: string
+    description: the GM certificate contents
+  security_group:
+    type: string
+    description: the security group to use
+    default: Infoblox
+  lan1_network:
+    type: string
+    description: the protocol network (must have a /24 network for auto addressing to work)
+    default: protocol-net
+    constraints:
+      - custom_constraint: neutron.network
+  virtual_router_id:
+    type: number
+    default: 200
+resources:
+  host_name:
+    type: OS::Heat::RandomString
+    properties:
+      length: 12
+      sequence: lowercase
+
+  vip_port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_param: lan1_network}
+      security_groups: [{get_param: security_group}]
+
+# We pre-allocate the port for LAN1, so that we have the IP address already for
+# injection via user_data
+  lan1_port_node_1:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_param: lan1_network}
+      security_groups: [{get_param: security_group}]
+
+  ha_port_node_1:
+    type: OS::Neutron::Port
+    depends_on: [vip_port]
+    properties:
+      network: {get_param: lan1_network}
+      security_groups: [{get_param: security_group}]
+
+  lan1_port_node_2:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_param: lan1_network}
+      security_groups: [{get_param: security_group}]
+
+  ha_port_node_2:
+    type: OS::Neutron::Port
+    depends_on: [vip_port]
+    properties:
+      network: {get_param: lan1_network}
+      security_groups: [{get_param: security_group}]
+
+# Each member needs a floating IP so Ceilometer can poll the member for QPS.
+
+  vip_floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_network}
+      port_id: {get_resource: vip_port}
+
+  node_1_floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_network}
+      port_id: {get_resource: lan1_port_node_1}
+
+  node_2_floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_network}
+      port_id: {get_resource: lan1_port_node_2}
+
+  grid_member:
+    type: Infoblox::Grid::Member
+    properties:
+      connection: {url: {get_param: wapi_url}, username: {get_param: wapi_username}, password: {get_param: wapi_password}, sslverify: {get_param: wapi_sslverify}}
+      name: { list_join: [ '.', [{ list_join: [ '-', [ 'member-dns', { get_resource: host_name } ]] }, 'localdomain' ]] }
+      model: { get_param: model }
+      LAN1: { get_resource: lan1_port_node_1 }
+      HA: { get_resource: ha_port_node_1 }
+      dns: { enable: True }
+      temp_licenses: ["vnios", "dns", "enterprise", "rpz"]
+      gm_ip: { get_param: gm_vip }
+      gm_certificate: { get_param: gm_cert }
+      remote_console_enabled: true
+      admin_password: infoblox
+      ha_pair: True
+      VIP: { get_resource: vip_port }
+      virtual_router_id: { get_param: virtual_router_id }
+      node2_HA: { get_resource: ha_port_node_2 }
+      node2_LAN1: { get_resource: lan1_port_node_2 }
+
+  node1:
+    type: OS::Nova::Server
+    properties:
+      name: { list_join: [ '-', [ 'member-dns', { get_resource: host_name }, 'node1' ]] }
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      networks: [{network: mgmt-net }, {port: { get_resource: lan1_port_node_1}},  {port: { get_resource: ha_port_node_1}} ]
+      config_drive: true
+      user_data_format: RAW
+      user_data: { get_attr: [grid_member, user_data] }
+
+  node2:
+    type: OS::Nova::Server
+    properties:
+      name: { list_join: [ '-', [ 'member-dns', { get_resource: host_name }, 'node2' ]] }
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      networks: [{network: mgmt-net }, {port: { get_resource: lan1_port_node_2}},  {port: { get_resource: ha_port_node_2}}]
+      config_drive: true
+      user_data_format: RAW
+      user_data: { get_attr: [grid_member, node2_user_data] }
+


### PR DESCRIPTION
Added template 'member-ha.yaml' to create HA pair member.
Modified template 'gm-ha.yaml' to crete HA pair GM without script.
